### PR TITLE
Fixed error "Call to undefined function opcache_reset()" if opcache is not loaded.

### DIFF
--- a/Resources/template.tpl
+++ b/Resources/template.tpl
@@ -3,7 +3,7 @@
 if (!extension_loaded('opcache')) {
     $success = false;
     $message = 'Opcode cache extension not loaded';
-} if (opcache_reset()) {
+} else if (opcache_reset()) {
     $success = true;
     $message = 'Opcode cache clear: success';
 } else {


### PR DESCRIPTION
The "else" was missing before the "if (opcache_reset())" in the template file.